### PR TITLE
feat: Make created_at field in Event model non-editable

### DIFF
--- a/events/models.py
+++ b/events/models.py
@@ -16,7 +16,7 @@ class Event(models.Model):
     banner = models.ImageField(upload_to="event_banners/")
     created_by = models.ForeignKey(User, on_delete=models.CASCADE, related_name="events")
     is_verified = models.BooleanField(default=False)
-    created_at = models.DateTimeField(auto_now_add=True)
+    created_at = models.DateTimeField(auto_now_add=True, editable=False)
     updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:


### PR DESCRIPTION
## Description

The created_at field in the Event model is updated  to be non-editable to ensure that it is only set when the record is created and cannot be modified afterward.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works